### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Test
@@ -21,9 +21,9 @@ jobs:
     needs: [ "test" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
     - name: Test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,9 +13,9 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X "github.com/mudler/yip/cmd.CLIVersion={{ .Tag }}"
-      - -X "github.com/mudler/yip/cmd.BuildTime={{ time "2006-01-02 15:04:05 MST" }}"
-      - -X "github.com/mudler/yip/cmd.BuildCommit={{ .FullCommit }}"
+      - -X "github.com/rancher/yip/cmd.CLIVersion={{ .Tag }}"
+      - -X "github.com/rancher/yip/cmd.BuildTime={{ time "2006-01-02 15:04:05 MST" }}"
+      - -X "github.com/rancher/yip/cmd.BuildCommit={{ .FullCommit }}"
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Updates:

* actions/checkout@v3 -> v4
* actions/setup-go@v4 -> v5

After seeing "Node.js 16 actions are deprecated" in the actions log.

Also update .goreleaser.yaml config.