### PR TITLE
Refactor dns plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/itchyny/gojq v0.12.15
 	github.com/joho/godotenv v1.5.1
-	github.com/moby/moby v25.0.4+incompatible
 	github.com/mudler/entities v0.0.0-20220905203055-68348bae0f49
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.0
@@ -39,7 +38,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/cloudflare/circl v1.3.8 // indirect
-	github.com/containerd/log v0.1.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/diskfs/go-diskfs v1.4.0 // indirect
 	github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.8 h1:j+V8jJt09PoeMFIu2uh5JUyEaIHTXVOHslFoLNAKqwI=
 github.com/cloudflare/circl v1.3.8/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
-github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
-github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -185,8 +183,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/moby v25.0.4+incompatible h1:vea1J80wDM5x5geaZSaywFkfFxLABJIQ3mmR4ewZGbU=
-github.com/moby/moby v25.0.4+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mudler/entities v0.0.0-20220905203055-68348bae0f49 h1:P1QgHLh0hX935j6m9K6rlSxc0mkD1UuIAOQEu+1VCW4=
 github.com/mudler/entities v0.0.0-20220905203055-68348bae0f49/go.mod h1:qquFT9tYp+/NO7tTotto4BT9zSRYSMDxo2PGZwujpFA=

--- a/pkg/plugins/dns.go
+++ b/pkg/plugins/dns.go
@@ -1,7 +1,10 @@
 package plugins
 
 import (
-	"github.com/moby/moby/libnetwork/resolvconf"
+	"bytes"
+	"os"
+	"strings"
+
 	"github.com/twpayne/go-vfs/v4"
 
 	"github.com/rancher/yip/pkg/logger"
@@ -20,6 +23,38 @@ func applyDNS(s schema.Stage) error {
 	if path == "" {
 		path = "/etc/resolv.conf"
 	}
-	_, err := resolvconf.Build(path, s.Dns.Nameservers, s.Dns.DnsSearch, s.Dns.DnsOptions)
-	return err
+	return writeResolvConf(path, s.Dns.Nameservers, s.Dns.DnsSearch, s.Dns.DnsOptions)
+}
+
+// Build generates and writes a configuration file to path containing a nameserver
+// entry for every element in nameservers, a "search" entry for every element in
+// dnsSearch, and an "options" entry for every element in dnsOptions. It returns
+// a File containing the generated content and its (sha256) hash.
+//
+// Note that the resolv.conf file is written, but the hash file is not.
+// Duplicated from https://github.com/moby/moby/blob/9d07820b221db010bf1bdc26ca904468804ca712/libnetwork/resolvconf/resolvconf.go#L131
+// Because of use of internal module.
+func writeResolvConf(path string, nameservers, dnsSearch, dnsOptions []string) error {
+	content := bytes.NewBuffer(nil)
+	if len(dnsSearch) > 0 {
+		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+	for _, dns := range nameservers {
+		if _, err := content.WriteString("nameserver " + dns + "\n"); err != nil {
+			return err
+		}
+	}
+	if len(dnsOptions) > 0 {
+		if optsString := strings.Join(dnsOptions, " "); strings.Trim(optsString, " ") != "" {
+			if _, err := content.WriteString("options " + optsString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return os.WriteFile(path, content.Bytes(), 0o644)
 }

--- a/pkg/plugins/dns_test.go
+++ b/pkg/plugins/dns_test.go
@@ -15,7 +15,7 @@
 package plugins_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -48,7 +48,7 @@ var _ = Describe("Dns", func() {
 			file, err := os.Open(temp + "/foo")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			b, err := ioutil.ReadAll(file)
+			b, err := io.ReadAll(file)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(string(b)).Should(Equal("nameserver 8.8.8.8\n"))


### PR DESCRIPTION
Our use of moby/moby for generating the resolvconf does not work after v26 upgrade because of their use of internal package.

We only use the upstream resolvconf.Build method, which is self-contained so this commit copies the upstream method to the dns plugin and removes the use of github.com/moby/moby module.