### PR TITLE
Fix deprecated goreleaser option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the upgrade to v6 --rm-dist was deprecated in favor of --clean.

More info here: https://goreleaser.com/deprecations/#-rm-dist