### PR TITLE
Do not return error when userdata not found

### DIFF
--- a/pkg/plugins/datasource.go
+++ b/pkg/plugins/datasource.go
@@ -152,7 +152,8 @@ func DataSources(l logger.Interface, s schema.Stage, fs vfs.FS, console Console)
 	}
 
 	if userdata == nil {
-		return fmt.Errorf("no metadata/userdata found")
+		l.Warn("No metadata/userdata found")
+		return nil
 	}
 
 	basePath := prv.ConfigPath
@@ -160,10 +161,8 @@ func DataSources(l logger.Interface, s schema.Stage, fs vfs.FS, console Console)
 		basePath = s.DataSources.Path
 	}
 
-	if userdata != nil {
-		if err := processUserData(l, basePath, userdata, fs, console); err != nil {
-			return err
-		}
+	if err := processUserData(l, basePath, userdata, fs, console); err != nil {
+		return err
 	}
 
 	//Apply the hostname if the provider extracted a hostname file

--- a/pkg/plugins/datasource_test.go
+++ b/pkg/plugins/datasource_test.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,7 +37,7 @@ var _ = Describe("Datasources", func() {
 		l := logrus.New()
 		l.SetLevel(logrus.DebugLevel)
 		l.SetOutput(io.Discard)
-		It("Runs datasources and fails to adquire any metadata", func() {
+		It("Runs datasources and fails to aquire any metadata", func() {
 			fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{})
 			Expect(err).Should(BeNil())
 			defer cleanup()
@@ -47,8 +46,7 @@ var _ = Describe("Datasources", func() {
 					Providers: []string{"cdrom"},
 				},
 			}, fs, testConsole)
-			Expect(err).To(HaveOccurred())
-			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
+			Expect(err).ToNot(HaveOccurred())
 			_, err = fs.Stat(providers.ConfigPath)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -75,8 +73,7 @@ var _ = Describe("Datasources", func() {
 				},
 			}, fs, testConsole)
 			elapsed := time.Since(start)
-			Expect(err).To(HaveOccurred())
-			Expect(strings.ToLower(err.Error())).To(ContainSubstring("no metadata/userdata found"))
+			Expect(err).ToNot(HaveOccurred())
 			// check if it took less than 10 seconds. If we were to run all those datasources one after the other
 			// it would take much more
 			Expect(elapsed).To(BeNumerically("<", 10*time.Second))


### PR DESCRIPTION
Not finding userdata/metadata is an expected outcome, log a warning instead of returning an error.